### PR TITLE
Load Fuse.js before index script

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,6 +122,7 @@
     <footer class="bg-gray-800 text-white text-center p-4">
         <p>&copy; 2025 Cloud Chronicles Blog. All rights reserved.</p>
     </footer>
+    <script src="https://cdn.jsdelivr.net/npm/fuse.js@6.6.2"></script>
     <script src="scripts/index.js"></script>
 </body>
 </html>

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -1,3 +1,8 @@
+// Ensure Fuse.js is loaded
+if (typeof Fuse === 'undefined') {
+    console.error('Fuse.js failed to load. Search functionality will not work.');
+}
+
 // Pagination variables
 let currentPage = 1;
 const postsPerPage = 5;


### PR DESCRIPTION
## Summary
- include Fuse.js from CDN on home page
- check for Fuse availability in `index.js`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885f9a6228883219102fa2e5afd1a5f