### PR TITLE
Add slug validation in post.js

### DIFF
--- a/scripts/post.js
+++ b/scripts/post.js
@@ -9,7 +9,8 @@ function stripFrontMatter(markdown) {
 const urlParams = new URLSearchParams(window.location.search);
 const slug = urlParams.get('slug');
 
-if (slug) {
+if (slug && /^[a-z0-9-]+$/i.test(slug)) {
+    // Slug passed regex validation; safe to fetch associated Markdown file
     console.log('Fetching post:', `posts/${slug}.md`);
     fetch(`posts/${slug}.md`)
         .then(response => response.text())
@@ -21,6 +22,9 @@ if (slug) {
             postContent.innerHTML = marked.parse(strippedMarkdown); // Updated to use marked.parse
         })
         .catch(error => console.error('Error loading post:', error));
+} else if (slug) {
+    // Invalid slug detected - do not fetch file to prevent file path abuse
+    document.getElementById('post-content').textContent = 'Invalid post slug.';
 } else {
     document.getElementById('post-content').innerHTML = '<p>Post not found.</p>';
 }


### PR DESCRIPTION
## Summary
- validate slug before fetching post file to prevent path abuse
- show error message if slug is invalid

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688606f72c9c8321a3e1bb6ff9787e76