### PR TITLE
Fix blog metadata parsing

### DIFF
--- a/posts.json
+++ b/posts.json
@@ -1,86 +1,86 @@
 [
   {
-    "title": "\"Cloud Best Practices\"",
-    "date": "\"2025-04-19\"",
-    "author": "\"Jane Smith\"",
+    "title": "Cloud Best Practices",
+    "date": "2025-04-19",
+    "author": "Jane Smith",
     "tags": [
-      "[\"generic\"]"
+      "generic"
     ],
-    "slug": "\"cloud-best-practices\"",
+    "slug": "cloud-best-practices",
     "excerpt": "Following proven cloud practices helps organizations achieve reliability and cost efficiency."
   },
   {
-    "title": "\"Cloud Computing Basics\"",
-    "date": "\"2025-04-19\"",
-    "author": "\"Jane Smith\"",
+    "title": "Cloud Computing Basics",
+    "date": "2025-04-19",
+    "author": "Jane Smith",
     "tags": [
-      "[\"cloud\"",
-      "\"basics\"]"
+      "cloud",
+      "basics"
     ],
-    "slug": "\"cloud-computing-basics\"",
+    "slug": "cloud-computing-basics",
     "excerpt": "# Cloud Computing Basics"
   },
   {
-    "title": "\"Understanding Cloud Deployment Models\"",
-    "date": "\"2025-04-19\"",
-    "author": "\"Alice Johnson\"",
+    "title": "Understanding Cloud Deployment Models",
+    "date": "2025-04-19",
+    "author": "Alice Johnson",
     "tags": [
-      "[\"cloud\"",
-      "\"deployment\"]"
+      "cloud",
+      "deployment"
     ],
-    "slug": "\"cloud-deployment-models\"",
+    "slug": "cloud-deployment-models",
     "excerpt": "# Understanding Cloud Deployment Models"
   },
   {
-    "title": "\"Cloud Security Best Practices\"",
-    "date": "\"2025-04-19\"",
-    "author": "\"John Doe\"",
+    "title": "Cloud Security Best Practices",
+    "date": "2025-04-19",
+    "author": "John Doe",
     "tags": [
-      "[\"cloud\"",
-      "\"security\"]"
+      "cloud",
+      "security"
     ],
-    "slug": "\"cloud-security-best-practices\"",
+    "slug": "cloud-security-best-practices",
     "excerpt": "# Cloud Security Best Practices"
   },
   {
-    "title": "\"Introduction to AWS\"",
-    "date": "\"2025-04-19\"",
-    "author": "\"John Doe\"",
+    "title": "Introduction to AWS",
+    "date": "2025-04-19",
+    "author": "John Doe",
     "tags": [
-      "[\"aws\"]"
+      "aws"
     ],
-    "slug": "\"intro-to-aws\"",
+    "slug": "intro-to-aws",
     "excerpt": "Amazon Web Services offers a broad set of global compute, storage, database, and other cloud capabilities."
   },
   {
-    "title": "\"Introduction to Azure\"",
-    "date": "\"2025-04-19\"",
-    "author": "\"Jane Smith\"",
+    "title": "Introduction to Azure",
+    "date": "2025-04-19",
+    "author": "Jane Smith",
     "tags": [
-      "[\"azure\"]"
+      "azure"
     ],
-    "slug": "\"intro-to-azure\"",
+    "slug": "intro-to-azure",
     "excerpt": "Azure provides a wide range of cloud services for building, deploying, and managing applications."
   },
   {
-    "title": "\"Introduction to GCP\"",
-    "date": "\"2025-04-19\"",
-    "author": "\"Alice Johnson\"",
+    "title": "Introduction to GCP",
+    "date": "2025-04-19",
+    "author": "Alice Johnson",
     "tags": [
-      "[\"gcp\"]"
+      "gcp"
     ],
-    "slug": "\"intro-to-gcp\"",
+    "slug": "intro-to-gcp",
     "excerpt": "Google Cloud Platform delivers secure and scalable infrastructure along with advanced analytics tools."
   },
   {
-    "title": "\"Sample Blog Post\"",
-    "date": "\"2025-04-19\"",
-    "author": "\"John Doe\"",
+    "title": "Sample Blog Post",
+    "date": "2025-04-19",
+    "author": "John Doe",
     "tags": [
-      "[\"sample\"",
-      "\"blog\"]"
+      "sample",
+      "blog"
     ],
-    "slug": "\"sample-post\"",
+    "slug": "sample-post",
     "excerpt": "# Sample Blog Post"
   }
 ]

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -3,6 +3,16 @@ const path = require('path');
 const postsDir = path.join(__dirname, '../posts');
 const outputFile = path.join(__dirname, '../posts.json');
 
+// Helper to remove wrapping quotes from front matter values
+function clean(value) {
+    const trimmed = value.trim();
+    if ((trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+        (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+        return trimmed.slice(1, -1);
+    }
+    return trimmed;
+}
+
 fs.readdir(postsDir, (err, files) => {
     if (err) {
         console.error('Error reading posts directory:', err);
@@ -18,18 +28,29 @@ fs.readdir(postsDir, (err, files) => {
 
         const frontmatter = metadata[1];
         const metadataObj = Object.fromEntries(
-            frontmatter.split('\n').filter(line => line).map(line => {
-                const [key, ...value] = line.split(':');
-                return [key.trim(), value.join(':').trim()];
-            })
+            frontmatter
+                .split('\n')
+                .filter(line => line)
+                .map(line => {
+                    const [key, ...value] = line.split(':');
+                    return [key.trim(), clean(value.join(':'))];
+                })
         );
 
+        const tags = metadataObj.tags
+            ? metadataObj.tags
+                  .replace(/^\[|\]$/g, '')
+                  .split(',')
+                  .map(tag => clean(tag))
+                  .filter(Boolean)
+            : [];
+
         return {
-            title: metadataObj.title,
-            date: metadataObj.date,
-            author: metadataObj.author,
-            tags: metadataObj.tags ? metadataObj.tags.split(',').map(tag => tag.trim()) : [],
-            slug: metadataObj.slug,
+            title: clean(metadataObj.title || ''),
+            date: clean(metadataObj.date || ''),
+            author: clean(metadataObj.author || ''),
+            tags,
+            slug: clean(metadataObj.slug || ''),
             excerpt: content.split('---')[2].trim().split('\n')[0] // First line after metadata
         };
     }).filter(post => post !== null);

--- a/scripts/rss.js
+++ b/scripts/rss.js
@@ -3,6 +3,16 @@ const path = require('path');
 const postsDir = path.join(__dirname, '../posts');
 const outputFile = path.join(__dirname, '../rss.xml');
 
+// Helper to remove wrapping quotes from front matter values
+function clean(value) {
+    const trimmed = value.trim();
+    if ((trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+        (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+        return trimmed.slice(1, -1);
+    }
+    return trimmed;
+}
+
 const siteUrl = 'https://your-blog-site.com';
 const rssHeader = `<?xml version="1.0" encoding="UTF-8" ?>
 <rss version="2.0">
@@ -30,17 +40,20 @@ fs.readdir(postsDir, (err, files) => {
 
         const frontmatter = metadata[1];
         const metadataObj = Object.fromEntries(
-            frontmatter.split('\n').filter(line => line).map(line => {
-                const [key, ...value] = line.split(':');
-                return [key.trim(), value.join(':').trim()];
-            })
+            frontmatter
+                .split('\n')
+                .filter(line => line)
+                .map(line => {
+                    const [key, ...value] = line.split(':');
+                    return [key.trim(), clean(value.join(':'))];
+                })
         );
 
         return `  <item>
-    <title>${metadataObj.title}</title>
-    <link>${siteUrl}/post.html?slug=${metadataObj.slug}</link>
-    <description>${metadataObj.title}</description>
-    <pubDate>${new Date(metadataObj.date).toUTCString()}</pubDate>
+    <title>${clean(metadataObj.title)}</title>
+    <link>${siteUrl}/post.html?slug=${clean(metadataObj.slug)}</link>
+    <description>${clean(metadataObj.title)}</description>
+    <pubDate>${new Date(clean(metadataObj.date)).toUTCString()}</pubDate>
   </item>`;
     }).join('\n');
 


### PR DESCRIPTION
## Summary
- strip quotes from post front matter to generate clean metadata
- ensure RSS feed uses sanitized metadata
- regenerate `posts.json` with cleaned values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6886084669a08321b58bc758e2881215