### PR TITLE
Add global dark mode script

### DIFF
--- a/404.html
+++ b/404.html
@@ -38,5 +38,6 @@
     <footer class="bg-gray-800 text-white text-center p-4">
         <p>&copy; 2025 Cloud Chronicles Blog. All rights reserved.</p>
     </footer>
+    <script src="scripts/theme.js"></script>
 </body>
 </html>

--- a/aws.html
+++ b/aws.html
@@ -59,5 +59,6 @@
             })
             .catch(error => console.error('Error loading posts:', error));
     </script>
+    <script src="scripts/theme.js"></script>
 </body>
 </html>

--- a/azure.html
+++ b/azure.html
@@ -59,5 +59,6 @@
             })
             .catch(error => console.error('Error loading posts:', error));
     </script>
+    <script src="scripts/theme.js"></script>
 </body>
 </html>

--- a/gcp.html
+++ b/gcp.html
@@ -59,5 +59,6 @@
             })
             .catch(error => console.error('Error loading posts:', error));
     </script>
+    <script src="scripts/theme.js"></script>
 </body>
 </html>

--- a/generic.html
+++ b/generic.html
@@ -59,5 +59,6 @@
             })
             .catch(error => console.error('Error loading posts:', error));
     </script>
+    <script src="scripts/theme.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -55,5 +55,6 @@
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/fuse.js@6.6.2"></script>
     <script src="scripts/index.js"></script>
+    <script src="scripts/theme.js"></script>
 </body>
 </html>

--- a/post.html
+++ b/post.html
@@ -40,5 +40,6 @@
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/marked@4.3.0/marked.min.js"></script>
     <script src="scripts/post.js"></script>
+    <script src="scripts/theme.js"></script>
 </body>
 </html>

--- a/posts.html
+++ b/posts.html
@@ -55,5 +55,6 @@
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/fuse.js@6.6.2"></script>
     <script src="scripts/index.js"></script>
+    <script src="scripts/theme.js"></script>
 </body>
 </html>

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -84,24 +84,6 @@ fetch('./posts.json')
             });
         }
 
-        // Enhanced dark mode toggle button design
-        const darkModeToggle = document.createElement('button');
-        darkModeToggle.textContent = localStorage.getItem('darkMode') === 'true' ? 'Light Mode' : 'Dark Mode';
-        darkModeToggle.className = 'fixed bottom-4 right-4 bg-gray-800 text-white px-4 py-2 rounded shadow-lg';
-        darkModeToggle.setAttribute('aria-label', 'Toggle dark mode');
-
-        darkModeToggle.addEventListener('click', () => {
-            const isDarkMode = document.body.classList.toggle('dark');
-            localStorage.setItem('darkMode', isDarkMode);
-            darkModeToggle.textContent = isDarkMode ? 'Light Mode' : 'Dark Mode';
-        });
-
-        document.body.appendChild(darkModeToggle);
-
-        // Apply saved dark mode preference
-        if (localStorage.getItem('darkMode') === 'true') {
-            document.body.classList.add('dark');
-        }
     })
     .catch(error => {
         console.error('Error loading posts:', error);

--- a/scripts/theme.js
+++ b/scripts/theme.js
@@ -1,0 +1,20 @@
+(function() {
+    if (localStorage.getItem('darkMode') === 'true') {
+        document.body.classList.add('dark');
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        const darkModeToggle = document.createElement('button');
+        darkModeToggle.textContent = document.body.classList.contains('dark') ? 'Light Mode' : 'Dark Mode';
+        darkModeToggle.className = 'fixed bottom-4 right-4 bg-gray-800 text-white px-4 py-2 rounded shadow-lg';
+        darkModeToggle.setAttribute('aria-label', 'Toggle dark mode');
+
+        darkModeToggle.addEventListener('click', () => {
+            const isDarkMode = document.body.classList.toggle('dark');
+            localStorage.setItem('darkMode', isDarkMode);
+            darkModeToggle.textContent = isDarkMode ? 'Light Mode' : 'Dark Mode';
+        });
+
+        document.body.appendChild(darkModeToggle);
+    });
+})();

--- a/tag.html
+++ b/tag.html
@@ -39,5 +39,6 @@
         <p>&copy; 2025 Cloud Chronicles Blog. All rights reserved.</p>
     </footer>
     <script src="scripts/tag.js"></script>
+    <script src="scripts/theme.js"></script>
 </body>
 </html>

--- a/tags.html
+++ b/tags.html
@@ -42,5 +42,6 @@
         <p>&copy; 2025 Cloud Chronicles Blog. All rights reserved.</p>
     </footer>
     <script src="scripts/tags.js"></script>
+    <script src="scripts/theme.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- move dark-mode toggling logic from `scripts/index.js` to new `scripts/theme.js`
- include `theme.js` on all HTML pages so the dark-mode toggle works site-wide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68860de218fc8321bcf5d2ce7d884f24